### PR TITLE
General improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,13 @@
 FROM golang:1.24-bookworm AS build
+
+ARG VERSION
+
 WORKDIR /go/src/mdq-publisher
 COPY build .
 
 RUN go mod download
 RUN go test -race ./...
-RUN CGO_ENABLED=0 go build -o /go/bin/mdq-publisher
+RUN CGO_ENABLED=0 go build -ldflags="-X main.version=$VERSION" -o /go/bin/mdq-publisher
 
 FROM gcr.io/distroless/static-debian12
 COPY --from=build /go/bin/mdq-publisher /

--- a/build/publisher.go
+++ b/build/publisher.go
@@ -267,9 +267,9 @@ func main() {
 				err = httpServerCertStore.loadCert()
 				if err != nil {
 					zlog.Err(err).Msg("Unable to reload x509 HTTP server cert from disk")
-				} else {
-					zlog.Info().Msg("Reloaded x509 HTTP server cert from disk")
+					continue
 				}
+				zlog.Info().Msg("Reloaded x509 HTTP server cert from disk")
 			}
 		}(httpServerCertStore)
 	}

--- a/build/publisher.go
+++ b/build/publisher.go
@@ -266,7 +266,7 @@ func main() {
 				zlog.Info().Msg("HUP received")
 				err = httpServerCertStore.loadCert()
 				if err != nil {
-					zlog.Error().Err(err).Msg("Unable to reload x509 HTTP server cert from disk")
+					zlog.Err(err).Msg("Unable to reload x509 HTTP server cert from disk")
 				} else {
 					zlog.Info().Msg("Reloaded x509 HTTP server cert from disk")
 				}

--- a/build/publisher.go
+++ b/build/publisher.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"encoding/hex"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -46,7 +47,12 @@ func (m *myMux) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			adresses := strings.Split(header, ",")
 			for _, adress := range adresses {
 				adress := strings.TrimSpace(adress)
-				merged_xffs = append(merged_xffs, adress)
+				ip := net.ParseIP(adress)
+				if ip == nil {
+					// Discard non valid X-Forwarded-For
+					continue
+				}
+				merged_xffs = append(merged_xffs, ip)
 			}
 
 		}

--- a/build/publisher.go
+++ b/build/publisher.go
@@ -303,13 +303,6 @@ func main() {
 
 	zlog.Info().Bool("tls", tlsBool).Msg("Starting up")
 	if tlsBool {
-		if _, err := os.Stat(serverCert); errors.Is(err, os.ErrNotExist) {
-			zlog.Fatal().Err(err).Msg("Missing cert: " + serverCert)
-		}
-		if _, err := os.Stat(serverKey); errors.Is(err, os.ErrNotExist) {
-			zlog.Fatal().Err(err).Msg("Missing key: " + serverKey)
-		}
-
 		if err := srv.ListenAndServeTLS("", ""); err != http.ErrServerClosed {
 			zlog.Fatal().Err(err).Msg("Listener failed")
 		}

--- a/build/publisher.go
+++ b/build/publisher.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha1" // #nosec MDQ is based on sha1 hashes
 	"crypto/tls"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/url"

--- a/build/publisher.go
+++ b/build/publisher.go
@@ -254,7 +254,6 @@ func main() {
 		httpServerCertStore, err := newCertStore(serverCert, serverKey)
 		if err != nil {
 			zlog.Fatal().Err(err).Msg("Unable to load x509 HTTP server cert from disk")
-			os.Exit(1)
 		}
 
 		tlsCfg.GetCertificate = httpServerCertStore.getServerCertficate

--- a/build/publisher.go
+++ b/build/publisher.go
@@ -263,7 +263,7 @@ func main() {
 			signal.Notify(sigHup, syscall.SIGHUP)
 
 			for range sigHup {
-				zlog.Info().Msgf("HUP received")
+				zlog.Info().Msg("HUP received")
 				err = httpServerCertStore.loadCert()
 				if err != nil {
 					zlog.Error().Err(err).Msg("Unable to reload x509 HTTP server cert from disk")

--- a/build/publisher.go
+++ b/build/publisher.go
@@ -6,8 +6,8 @@ import (
 	"crypto/tls"
 	"encoding/hex"
 	"fmt"
-	"net"
 	"net/http"
+	"net/netip"
 	"net/url"
 	"os"
 	"os/signal"
@@ -47,12 +47,13 @@ func (m *myMux) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			adresses := strings.Split(header, ",")
 			for _, adress := range adresses {
 				adress := strings.TrimSpace(adress)
-				ip := net.ParseIP(adress)
-				if ip == nil {
-					// Discard non valid X-Forwarded-For
+				ip, err := netip.ParseAddr(adress)
+				if err != nil {
+					fmt.Printf("Not IP %s\n", adress)
 					continue
 				}
-				merged_xffs = append(merged_xffs, ip)
+
+				merged_xffs = append(merged_xffs, ip.String())
 			}
 
 		}

--- a/build/publisher.go
+++ b/build/publisher.go
@@ -225,7 +225,7 @@ func main() {
 	}
 
 	serverCert := getEnv("PUBLISHER_CERT", "/etc/certs/cert.pem")
-	srvKey := getEnv("PUBLISHER_KEY", "/etc/certs/privkey.pem")
+	serverKey := getEnv("PUBLISHER_KEY", "/etc/certs/privkey.pem")
 
 	chain := aliceRequestLoggerChain(zlog)
 
@@ -252,7 +252,7 @@ func main() {
 	}
 
 	if tlsBool {
-		httpServerCertStore, err := newCertStore(serverCert, srvKey)
+		httpServerCertStore, err := newCertStore(serverCert, serverKey)
 		if err != nil {
 			zlog.Fatal().Err(err).Msg("Unable to load x509 HTTP server cert from disk")
 			os.Exit(1)
@@ -306,8 +306,8 @@ func main() {
 		if _, err := os.Stat(serverCert); errors.Is(err, os.ErrNotExist) {
 			zlog.Fatal().Err(err).Msg("Missing cert: " + serverCert)
 		}
-		if _, err := os.Stat(srvKey); errors.Is(err, os.ErrNotExist) {
-			zlog.Fatal().Err(err).Msg("Missing key: " + srvKey)
+		if _, err := os.Stat(serverKey); errors.Is(err, os.ErrNotExist) {
+			zlog.Fatal().Err(err).Msg("Missing key: " + serverKey)
 		}
 
 		if err := srv.ListenAndServeTLS("", ""); err != http.ErrServerClosed {

--- a/jenkins-docker-build-and-push.sh
+++ b/jenkins-docker-build-and-push.sh
@@ -36,7 +36,7 @@ DOCKER_TAG="${BASE_TAG}:${VERSION}"
 LATEST_TAG="${BASE_TAG}:latest"
 echo "${script_name}: building DOCKER_TAG ${DOCKER_TAG} ${LATEST_TAG}"
 
-docker build --tag "${DOCKER_TAG}" --tag "${LATEST_TAG}" .
+docker build --build-arg "VERSION=${VERSION}" --tag "${DOCKER_TAG}" --tag "${LATEST_TAG}" .
 #docker push --all-tags ${BASE_TAG}
 # Workaround for old docker verison on CI
 for tag in ${DOCKER_TAG} ${LATEST_TAG}; do


### PR DESCRIPTION
* Possibility to reload TLS certificate without restart (listening for HUP)
* Log all proxies received in the X-Forwarded-For header(s)
* Graceful shutdown - allowing all clients to finish their request before shutting down (don't worry, we have a timeout)
* The log now includes more useful information when debugging. Like hostname and which build is running

Maybe each point should have been it's own PR 🤷‍♂️